### PR TITLE
The path for compile_commands.json is hardcoded to CMAKE_BINARY_DIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -269,7 +269,7 @@ add_custom_command(
   DEPENDS ${LIB_TARGET}
   OUTPUT ${PROJECT_SOURCE_DIR}/compile_commands.json
   COMMAND ${CMAKE_COMMAND} -E copy
-    ${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json
+    ${CMAKE_BINARY_DIR}/compile_commands.json
     ${PROJECT_SOURCE_DIR}/compile_commands.json
   )
 add_custom_target(compile_commands ALL


### PR DESCRIPTION
The path for compile_commands.json is hardcoded to CMAKE_BINARY_DIR. In case of building it as a standalone project the CMAKE_CURRENT_BINARY_DIR and CMAKE_BINARY_DIR are the same, but in case of building with CPM, or other ways where it is in some subdirectory, it will create the compile_commands.json in the CMAKE_BINARY_DIR, and try to copy it from CMAKE_CURRENT_BINARY_DIR, and it will fail.

https://github.com/Kitware/CMake/blob/572f3105c1a011854c29d7764d5c89312c0c8932/Source/cmGlobalNinjaGenerator.cxx#L1219